### PR TITLE
refactor: Migrate complex grid layouts to Svelte scoped styles

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,9 +18,7 @@
 				Kodowgは日本語の「小道具」にインスパイアされた言葉です。日常のちょっとしたタスクに便利なツールを提供します。
 			</p>
 		</div>
-		<div
-			class="grid grid-cols-[repeat(auto-fit,minmax(theme(spacing.80),1fr))] gap-4"
-		>
+		<div class="grid gap-4" data-grid>
 			{#each tools as tool (tool.href)}
 				<a
 					href={resolve(tool.href)}
@@ -49,3 +47,11 @@
 		</ul>
 	</div>
 </div>
+
+<style lang="postcss">
+	@reference "tailwindcss";
+
+	[data-grid] {
+		grid-template-columns: repeat(auto-fit, minmax(--spacing(80), 1fr));
+	}
+</style>

--- a/src/routes/timer/+page.svelte
+++ b/src/routes/timer/+page.svelte
@@ -166,7 +166,7 @@
 </div>
 
 <style lang="postcss">
-	@reference "../../app.css";
+	@reference "tailwindcss";
 
 	.input {
 		@apply max-w-32 [appearance:textfield] sm:max-w-44 md:max-w-56 lg:max-w-64 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none;


### PR DESCRIPTION
Replaced direct Tailwind CSS utility classes for complex grid definitions with Svelte's scoped style blocks using PostCSS.

This approach enhances maintainability and encapsulation of component-specific layouts, moving styling logic closer to the component definition.

Additionally, updated style reference in the timer component to use 'tailwindcss' for consistency.